### PR TITLE
Command cancellation decorator

### DIFF
--- a/src/Shipwright.Core/Commands/Decorators/CancellationCommandDecorator.cs
+++ b/src/Shipwright.Core/Commands/Decorators/CancellationCommandDecorator.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+namespace Shipwright.Core.Commands.Decorators;
+
+/// <summary>
+/// Decorates a command handler to add pre-execute cancellation.
+/// </summary>
+/// <typeparam name="TCommand">Type of the command whose handler to decorate.</typeparam>
+/// <typeparam name="TResult">Type returned when the command is executed.</typeparam>
+public class CancellationCommandDecorator<TCommand, TResult> : ICommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+{
+    readonly ICommandHandler<TCommand, TResult> _inner;
+
+    public CancellationCommandDecorator( ICommandHandler<TCommand, TResult> inner )
+    {
+        _inner = inner ?? throw new ArgumentNullException( nameof(inner) );
+    }
+
+    public async Task<TResult> Execute( TCommand command, CancellationToken cancellationToken )
+    {
+        if ( command == null ) throw new ArgumentNullException( nameof(command) );
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _inner.Execute( command, cancellationToken );
+    }
+}

--- a/src/Shipwright.Test/Core/Commands/Decorators/CancellationCommandDecoratorTests.cs
+++ b/src/Shipwright.Test/Core/Commands/Decorators/CancellationCommandDecoratorTests.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+namespace Shipwright.Core.Commands.Decorators;
+
+public abstract class CancellationCommandDecoratorTests
+{
+    Mock<ICommandHandler<FakeCommand, Guid>> inner = new( MockBehavior.Strict );
+    ICommandHandler<FakeCommand, Guid> instance() => new CancellationCommandDecorator<FakeCommand, Guid>( inner?.Object! );
+
+    public class Constructor : CancellationCommandDecoratorTests
+    {
+        [Fact]
+        public void requires_inner()
+        {
+            inner = null!;
+            Assert.Throws<ArgumentNullException>( nameof(inner), instance );
+        }
+    }
+
+    public abstract class Execute : CancellationCommandDecoratorTests
+    {
+        FakeCommand command = new();
+        CancellationToken cancellationToken;
+        Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+        [Fact]
+        public async Task requires_command()
+        {
+            command = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>( nameof(command), method );
+        }
+
+        public class WhenCanceled : Execute
+        {
+            [Fact]
+            public async Task throws_operation_canceled()
+            {
+                cancellationToken = new( true );
+                await Assert.ThrowsAsync<OperationCanceledException>( method );
+            }
+        }
+
+        public class WhenNotCanceled : Execute
+        {
+            [Fact]
+            public async Task returns_result_from_executed_inner_handler()
+            {
+                cancellationToken = new( false );
+
+                var expected = Guid.NewGuid();
+                inner.Setup( _ => _.Execute( command, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                actual.Should().Be( expected );
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Problem
As a developer, I want to treat command cancellation as a cross-cutting concern. All commands should check for cancellation prior to executing.

# Solution
Add a decorator that can added to all handlers automatically by dependency injection. This handler checks the cancellation token prior to invoking the inner handler.