### PR TITLE
Command validation decorator

### DIFF
--- a/Shipwright.sln.DotSettings
+++ b/Shipwright.sln.DotSettings
@@ -3,6 +3,7 @@
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;
     
 &lt;/Patterns&gt;</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionalAccessQualifierIsNonNullableAccordingToAPIContract/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBeProtected_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>

--- a/src/Shipwright.Core/Commands/Decorators/ValidationCommandDecorator.cs
+++ b/src/Shipwright.Core/Commands/Decorators/ValidationCommandDecorator.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+using FluentValidation;
+
+namespace Shipwright.Core.Commands.Decorators;
+
+/// <summary>
+/// Decorates a command handler to add pre-execute validation.
+/// </summary>
+/// <typeparam name="TCommand">Type of the command whose handler to decorate.</typeparam>
+/// <typeparam name="TResult">Type returned when the command is executed.</typeparam>
+public class ValidationCommandDecorator<TCommand, TResult> : ICommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+{
+    readonly ICommandHandler<TCommand, TResult> _inner;
+    readonly IValidator<TCommand> _validator;
+
+    public ValidationCommandDecorator( ICommandHandler<TCommand, TResult> inner, IValidator<TCommand> validator )
+    {
+        _inner = inner ?? throw new ArgumentNullException( nameof(inner) );
+        _validator = validator ?? throw new ArgumentNullException( nameof(validator) );
+    }
+
+    public async Task<TResult> Execute( TCommand command, CancellationToken cancellationToken )
+    {
+        if ( command == null ) throw new ArgumentNullException( nameof(command) );
+
+        var result = await _validator.ValidateAsync( command, cancellationToken );
+
+        if ( !result.IsValid )
+            throw new ValidationException( $"Validation failed for command type: {typeof(TCommand)}", result.Errors );
+
+        return await _inner.Execute( command, cancellationToken );
+    }
+}

--- a/src/Shipwright.Core/Shipwright.Core.csproj
+++ b/src/Shipwright.Core/Shipwright.Core.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
     <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="8.0.1" />
   </ItemGroup>

--- a/src/Shipwright.Test/Core/Commands/Decorators/ValidationCommandDecoratorTests.cs
+++ b/src/Shipwright.Test/Core/Commands/Decorators/ValidationCommandDecoratorTests.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+using AutoFixture;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Shipwright.Core.Commands.Decorators;
+
+public abstract class ValidationCommandDecoratorTests
+{
+    Mock<ICommandHandler<FakeCommand, Guid>> inner = new( MockBehavior.Strict );
+    Mock<IValidator<FakeCommand>> validator = new( MockBehavior.Strict );
+    ICommandHandler<FakeCommand, Guid> instance() => new ValidationCommandDecorator<FakeCommand, Guid>( inner?.Object!, validator?.Object! );
+
+    public class Constructor : ValidationCommandDecoratorTests
+    {
+        [Fact]
+        public void requires_inner()
+        {
+            inner = null!;
+            Assert.Throws<ArgumentNullException>( nameof(inner), instance );
+        }
+
+        [Fact]
+        public void requires_validator()
+        {
+            validator = null!;
+            Assert.Throws<ArgumentNullException>( nameof(validator), instance );
+        }
+    }
+
+    public abstract class Execute : ValidationCommandDecoratorTests
+    {
+        FakeCommand command = new();
+        CancellationToken cancellationToken;
+        Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+        [Fact]
+        public async Task requires_command()
+        {
+            command = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>( nameof(command), method );
+        }
+
+        public class WhenCommandIsValid : Execute
+        {
+            [Theory]
+            [BooleanCases]
+            public async Task returns_result_from_executed_inner_handler( bool canceled )
+            {
+                cancellationToken = new( canceled );
+
+                var success = new ValidationResult( Array.Empty<ValidationFailure>() );
+                validator.Setup( _ => _.ValidateAsync( command, cancellationToken ) ).ReturnsAsync( success );
+
+                var expected = Guid.NewGuid();
+                inner.Setup( _ => _.Execute( command, cancellationToken ) ).ReturnsAsync( expected );
+
+                var actual = await method();
+                actual.Should().Be( expected );
+            }
+        }
+
+        public class WhenCommandIsNotValid : Execute
+        {
+            [Theory]
+            [BooleanCases]
+            public async Task throws_validation( bool canceled )
+            {
+                cancellationToken = new( canceled );
+
+                var errors = new Fixture().CreateMany<ValidationFailure>().ToArray();
+                var failure = new ValidationResult( errors );
+                validator.Setup( _ => _.ValidateAsync( command, cancellationToken ) ).ReturnsAsync( failure );
+
+                var ex = await Assert.ThrowsAsync<ValidationException>( method );
+                ex.Errors.Should().BeEquivalentTo( errors );
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Problem
As a developer, I want to validate commands at runtime to ensure they are correct.

# Solution
Created a decorator that can be added via dependency injection which will locate and execute a FluentValidation validator and prevent the command from being executed if it is not valid.