### PR TITLE
DbUpsert transformation

### DIFF
--- a/Shipwright.sln.DotSettings
+++ b/Shipwright.sln.DotSettings
@@ -46,4 +46,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ctop/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DSCtop/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dataflows/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Inequivalent/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TTCO/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Shipwright.Core/Dataflows/Record.cs
+++ b/src/Shipwright.Core/Dataflows/Record.cs
@@ -78,4 +78,13 @@ public record Record
         // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         return value != null;
     }
+
+    /// <summary>
+    /// Returns the value if it is found in the record, otherwise returns the default value.
+    /// </summary>
+    /// <param name="key">Record field whose value to return.</param>
+    /// <param name="default">Default value to return if none is found in the record. Defaults to null.</param>
+    public object? GetValueOrDefault( string key, object? @default = null ) => TryGetValue( key, out var value )
+        ? value
+        : @default;
 }

--- a/src/Shipwright.Core/Dataflows/Transformations/DbUpsert.cs
+++ b/src/Shipwright.Core/Dataflows/Transformations/DbUpsert.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+using FluentValidation;
+using Shipwright.Databases;
+
+namespace Shipwright.Dataflows.Transformations;
+
+/// <summary>
+/// Transformation that updates database records, inserting new ones if they do not exist.
+/// </summary>
+[UsedImplicitly]
+public record DbUpsert : Transformation
+{
+    /// <summary>
+    /// Connection information for the target database.
+    /// </summary>
+
+    public DbConnectionInfo ConnectionInfo { get; init; } = null!;
+
+    /// <summary>
+    /// Database table whose records to update.
+    /// This can be a quoted name.
+    /// </summary>
+    public string Table { get; init; } = null!;
+
+    /// <summary>
+    /// Validator for the <see cref="DbUpsert"/> transformation.
+    /// </summary>
+    public class Validator : AbstractValidator<DbUpsert>
+    {
+        public Validator()
+        {
+            RuleFor( _ => _.ConnectionInfo ).NotNull();
+            RuleFor( _ => _.Table ).NotEmpty();
+        }
+    }
+}

--- a/src/Shipwright.Core/Dataflows/Transformations/DbUpsert.cs
+++ b/src/Shipwright.Core/Dataflows/Transformations/DbUpsert.cs
@@ -26,6 +26,35 @@ public record DbUpsert : Transformation
     public string Table { get; init; } = null!;
 
     /// <summary>
+    /// Column participation type.
+    /// </summary>
+    public enum ColumnType
+    {
+        /// <summary>
+        /// Key columns are used to locate the existing record.
+        /// Their values are inserted for new records, but never updated.
+        /// </summary>
+        Key,
+
+        /// <summary>
+        /// Insert columns are inserted for new records, but never updated.
+        /// Useful for record insert metadata.
+        /// </summary>
+        Insert,
+
+        /// <summary>
+        /// Update columns are inserted for new records, and updated when their values have changed.
+        /// </summary>
+        Update,
+
+        /// <summary>
+        /// Trigger columns are inserted for new records, and only updated when an Update column value has changed.
+        /// Useful for record update metadata.
+        /// </summary>
+        Trigger,
+    }
+    
+    /// <summary>
     /// Validator for the <see cref="DbUpsert"/> transformation.
     /// </summary>
     public class Validator : AbstractValidator<DbUpsert>

--- a/src/Shipwright.Core/Dataflows/Transformations/DbUpsert.cs
+++ b/src/Shipwright.Core/Dataflows/Transformations/DbUpsert.cs
@@ -334,11 +334,29 @@ public record DbUpsert : Transformation
         /// <summary>
         /// Inserts a new record into the database.
         /// </summary>
+        /// <param name="values">Record values indexed by column name.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public virtual async Task Insert( Dictionary<string,object?> values, CancellationToken cancellationToken )
+        {
+            using var connection = _connectionFactory.Create( _transformation.ConnectionInfo );
+            var db = new QueryFactory( connection, _compiler );
+            var query = db.Query( _transformation.Table );
+            await query.InsertAsync( values, cancellationToken: cancellationToken );
+        }
+
+        /// <summary>
+        /// Inserts a new record into the database.
+        /// </summary>
         /// <param name="record">Record containing the values to insert.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
-        public virtual Task Insert( Record record, CancellationToken cancellationToken )
+        public virtual async Task Insert( Record record, CancellationToken cancellationToken )
         {
-            throw new NotImplementedException();
+            var values = new Dictionary<string, object?>();
+
+            foreach ( var (_, field, column) in _transformation.Fields )
+                values[column] = record.GetValueOrDefault( field );
+
+            await Insert( values, cancellationToken );
         }
 
         /// <summary>

--- a/src/Shipwright.Core/Shipwright.Core.csproj
+++ b/src/Shipwright.Core/Shipwright.Core.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="3.0.0" />
     <PackageReference Include="CsvHelper" Version="27.2.1" />
-    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="FluentValidation" Version="11.0.2" />
     <PackageReference Include="Identifiable" Version="4.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
@@ -18,6 +17,7 @@
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.2.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.61" />
+    <PackageReference Include="SqlKata.Execution" Version="2.3.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Shipwright.Test/Dataflows/AutoFixtureExtensions.cs
+++ b/src/Shipwright.Test/Dataflows/AutoFixtureExtensions.cs
@@ -2,9 +2,7 @@
 // Copyright (c) TTCO Holding Company, Inc. and Contributors
 // All Rights Reserved.
 
-using AutoFixture;
 using AutoFixture.Kernel;
-using Microsoft.Extensions.Configuration;
 using Shipwright.Databases;
 using Shipwright.Dataflows.EventSinks;
 using Shipwright.Dataflows.Sources;
@@ -21,6 +19,10 @@ public static class AutoFixtureExtensions
         fixture.Customizations.Add( new TypeRelay( typeof(EventSink), typeof(FakeEventSink) ) );
         fixture.Customizations.Add( new TypeRelay( typeof(DbConnectionInfo), typeof(FakeDbConnectionInfo) ) );
         fixture.Customize<Dataflow>( dataflow => dataflow.Without( _ => _.Configuration ) );
+
+        // ensure that dbupsert field maps have one of each column type
+        fixture.Customize<DbUpsert>( upsert => upsert.With( _ => _.Fields, () =>
+            Enum.GetValues<DbUpsert.ColumnType>().Select( type => new DbUpsert.FieldMap( type, fixture.Create<string>(), fixture.Create<string>() ) ).ToList() ) );
 
         return fixture;
     }

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
@@ -34,7 +34,8 @@ public class FactoryTests
         {
             cancellationToken = new( canceled );
             var actual = await method();
-            actual.Should().BeOfType<DbUpsert.Handler>();
+            var handler = actual.Should().BeOfType<DbUpsert.Handler>().Subject;
+            handler._transformation.Should().BeSameAs( transformation );
         }
     }
 }

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
@@ -2,18 +2,28 @@
 // Copyright (c) TTCO Holding Company, Inc. and Contributors
 // All Rights Reserved.
 
+using JetBrains.Annotations;
+using Shipwright.Databases;
+using SqlKata.Compilers;
+
 namespace Shipwright.Dataflows.Transformations.DbUpsertTests;
 
 public class FactoryTests
 {
-    ITransformationHandlerFactory<DbUpsert> instance() => new DbUpsert.Factory();
+    Mock<IDbConnectionFactory> connectionFactory = new( MockBehavior.Strict );
+    ITransformationHandlerFactory<DbUpsert> instance() => new DbUpsert.Factory( connectionFactory?.Object! );
 
     public class Constructor : FactoryTests
     {
-
+        [Fact]
+        public void requires_connectionFactory()
+        {
+            connectionFactory = null!;
+            Assert.Throws<ArgumentNullException>( nameof(connectionFactory), instance );
+        }
     }
 
-    public class Create : FactoryTests
+    public abstract class Create : FactoryTests
     {
         DbUpsert transformation = new Fixture().WithDataflowCustomization().Create<DbUpsert>();
         CancellationToken cancellationToken;
@@ -28,14 +38,28 @@ public class FactoryTests
             await Assert.ThrowsAsync<ArgumentNullException>( nameof(transformation), method );
         }
 
-        [Theory]
-        [BooleanCases]
-        public async Task returns_handler( bool canceled )
+        public abstract class ExpectsCompilerType<TCompiler> : Create where TCompiler : Compiler
         {
-            cancellationToken = new( canceled );
-            var actual = await method();
-            var handler = actual.Should().BeOfType<DbUpsert.Handler>().Subject;
-            handler._transformation.Should().BeSameAs( transformation );
+            [Theory]
+            [BooleanCases]
+            public async Task returns_handler( bool canceled )
+            {
+                cancellationToken = new( canceled );
+                var actual = await method();
+                var handler = actual.Should().BeOfType<DbUpsert.Handler>().Subject;
+                handler._transformation.Should().BeSameAs( transformation );
+                handler._connectionFactory.Should().BeSameAs( connectionFactory.Object );
+                handler._compiler.Should().BeOfType<TCompiler>();
+            }
+        }
+
+        [UsedImplicitly]
+        public class WhenOracle : ExpectsCompilerType<OracleCompiler>
+        {
+            public WhenOracle()
+            {
+                transformation = transformation with { ConnectionInfo = new OracleConnectionInfo( new Fixture().Create<string>() ) };
+            }
         }
     }
 }

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/FactoryTests.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests;
+
+public class FactoryTests
+{
+    ITransformationHandlerFactory<DbUpsert> instance() => new DbUpsert.Factory();
+
+    public class Constructor : FactoryTests
+    {
+
+    }
+
+    public class Create : FactoryTests
+    {
+        DbUpsert transformation = new Fixture().WithDataflowCustomization().Create<DbUpsert>();
+        CancellationToken cancellationToken;
+        Task<ITransformationHandler> method() => instance().Create( transformation, cancellationToken );
+
+        [Theory]
+        [BooleanCases]
+        public async Task requires_transformation( bool canceled )
+        {
+            cancellationToken = new( canceled );
+            transformation = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>( nameof(transformation), method );
+        }
+
+        [Theory]
+        [BooleanCases]
+        public async Task returns_handler( bool canceled )
+        {
+            cancellationToken = new( canceled );
+            var actual = await method();
+            actual.Should().BeOfType<DbUpsert.Handler>();
+        }
+    }
+}

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
@@ -533,4 +533,31 @@ public class HandlerTests
             }
         }
     }
+
+    public class Insert : HandlerTests
+    {
+        Record record;
+        CancellationToken cancellationToken;
+        Task method() => mock.Object.Insert( record, cancellationToken );
+
+        public Insert()
+        {
+            record = fixture.Create<Record>();
+        }
+
+        [Fact]
+        public async Task inserts_all_mapped_column_values()
+        {
+            var expected = new Dictionary<string, object?>();
+
+            foreach ( var (_, field, column) in transformation.Fields )
+                expected[column] = record[field] = fixture.Create<string>();
+
+            var actual = new List<Dictionary<string, object?>>();
+            mock.Setup( _ => _.Insert( Capture.In( actual ), cancellationToken ) ).Returns( Task.CompletedTask );
+
+            await method();
+            actual.Should().ContainSingle().Subject.Should().BeEquivalentTo( expected );
+        }
+    }
 }

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/HandlerTests.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+using System.Collections;
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests;
+
+public class HandlerTests
+{
+    readonly Fixture fixture = new Fixture().WithDataflowCustomization();
+    Mock<DbUpsert.Handler> mock;
+    Mock<DbUpsert.Handler> instance() => new( MockBehavior.Default ) { CallBase = true };
+
+    public HandlerTests()
+    {
+        mock = instance();
+    }
+
+    public class Constructor : HandlerTests
+    {
+        ITransformationHandler constructor() => new DbUpsert.Handler();
+    }
+
+    public abstract class Transform : HandlerTests
+    {
+        Record record;
+        CancellationToken cancellationToken;
+        Task method() => mock.Object.Transform( record, cancellationToken );
+
+        protected Transform()
+        {
+            record = fixture.Create<Record>();
+        }
+
+        [Theory]
+        [BooleanCases]
+        public async Task requires_record( bool canceled )
+        {
+            cancellationToken = new( canceled );
+            record = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>( nameof(record), method );
+        }
+
+        public class WhenNoExistingRecord : Transform
+        {
+            [Theory]
+            [BooleanCases]
+            public async Task performs_insert( bool canceled )
+            {
+                cancellationToken = new( canceled );
+
+                var sequence = new MockSequence();
+                var releaser = new Mock<IDisposable>( MockBehavior.Strict );
+                mock.InSequence( sequence ).Setup( _ => _.Lock( record, cancellationToken ) ).ReturnsAsync( releaser.Object );
+                mock.InSequence( sequence ).Setup( _ => _.Select( record, cancellationToken ) ).ReturnsAsync( Array.Empty<dynamic>() );
+                mock.InSequence( sequence ).Setup( _ => _.Insert( record, cancellationToken ) ).Returns( Task.CompletedTask );
+                releaser.InSequence( sequence ).Setup( _ => _.Dispose() );
+
+                await method();
+                releaser.Verify( _ => _.Dispose(), Times.Once() );
+            }
+        }
+
+        public class WhenOneExistingRecordWithChanges : Transform
+        {
+            [Theory]
+            [BooleanCases]
+            public async Task performs_update( bool canceled )
+            {
+                cancellationToken = new( canceled );
+
+                var sequence = new MockSequence();
+                var releaser = new Mock<IDisposable>( MockBehavior.Strict );
+                var existing = fixture.Create<IDictionary<string, object?>>();
+                var changes = fixture.Create<Dictionary<string, object?>>();
+                mock.InSequence( sequence ).Setup( _ => _.Lock( record, cancellationToken ) ).ReturnsAsync( releaser.Object );
+                mock.InSequence( sequence ).Setup( _ => _.Select( record, cancellationToken ) ).ReturnsAsync( new [] { existing } );
+                mock.InSequence( sequence ).Setup( _ => _.TryGetChanges( record, existing, out changes ) ).Returns( true );
+                mock.InSequence( sequence ).Setup( _ => _.Update( record, changes, cancellationToken ) ).Returns( Task.CompletedTask );
+                releaser.InSequence( sequence ).Setup( _ => _.Dispose() );
+
+                await method();
+                releaser.Verify( _ => _.Dispose(), Times.Once() );
+            }
+        }
+
+        public class WhenOneExistingRecordWithoutChanges : Transform
+        {
+            [Theory]
+            [BooleanCases]
+            public async Task does_not_update( bool canceled )
+            {
+                cancellationToken = new( canceled );
+
+                var sequence = new MockSequence();
+                var releaser = new Mock<IDisposable>( MockBehavior.Strict );
+                var existing = fixture.Create<IDictionary<string, object?>>();
+                var changes = fixture.Create<Dictionary<string, object?>>();
+                mock.InSequence( sequence ).Setup( _ => _.Lock( record, cancellationToken ) ).ReturnsAsync( releaser.Object );
+                mock.InSequence( sequence ).Setup( _ => _.Select( record, cancellationToken ) ).ReturnsAsync( new [] { existing } );
+                mock.InSequence( sequence ).Setup( _ => _.TryGetChanges( record, existing, out changes ) ).Returns( false );
+                releaser.InSequence( sequence ).Setup( _ => _.Dispose() );
+
+                await method();
+                releaser.Verify( _ => _.Dispose(), Times.Once() );
+                mock.Verify( _ => _.Update( record, changes, cancellationToken ), Times.Never() );
+            }
+        }
+
+        public class WhenMultipleExistingRecords : Transform
+        {
+            [Theory]
+            [BooleanCases]
+            public async Task throws_invalid_operation( bool canceled )
+            {
+                cancellationToken = new( canceled );
+
+                var sequence = new MockSequence();
+                var releaser = new Mock<IDisposable>( MockBehavior.Strict );
+                var matches = fixture.CreateMany<dynamic>();
+                mock.InSequence( sequence ).Setup( _ => _.Lock( record, cancellationToken ) ).ReturnsAsync( releaser.Object );
+                mock.InSequence( sequence ).Setup( _ => _.Select( record, cancellationToken ) ).ReturnsAsync( matches );
+                releaser.InSequence( sequence ).Setup( _ => _.Dispose() );
+
+                await Assert.ThrowsAsync<InvalidOperationException>( method );
+                releaser.Verify( _ => _.Dispose(), Times.Once() );
+            }
+        }
+    }
+}

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -100,6 +100,14 @@ public class ValidatorTests
         }
 
         [Fact]
+        public async Task cannot_have_null_replace_delegate()
+        {
+            instance.Fields.Add( _fixture.Create<DbUpsert.FieldMap>() with { Replace = null! } );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Fact]
         public async Task requires_a_key_column()
         {
             var keys = instance.Fields.Where( _ => _.Type == DbUpsert.ColumnType.Key ).ToArray();

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -134,4 +134,144 @@ public class ValidatorTests
             result.ShouldNotHaveValidationErrorFor( _ => _.Fields );
         }
     }
+
+    public class BeforeInsert : ValidatorTests
+    {
+        [Fact]
+        public async Task cannot_be_null()
+        {
+            instance = instance with { BeforeInsert = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.BeforeInsert );
+        }
+
+        [Fact]
+        public async Task cannot_contain_null_elements()
+        {
+            instance.BeforeInsert.Add( null! );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.BeforeInsert );
+        }
+
+        [Fact]
+        public async Task valid_when_empty()
+        {
+            instance.BeforeInsert.Clear();
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.BeforeInsert );
+        }
+
+        [Fact]
+        public async Task valid_when_has_elements()
+        {
+            instance.BeforeInsert.Add( new FakeTransformation() );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.BeforeInsert );
+        }
+    }
+
+    public class AfterInsert : ValidatorTests
+    {
+        [Fact]
+        public async Task cannot_be_null()
+        {
+            instance = instance with { AfterInsert = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.AfterInsert );
+        }
+
+        [Fact]
+        public async Task cannot_contain_null_elements()
+        {
+            instance.AfterInsert.Add( null! );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.AfterInsert );
+        }
+
+        [Fact]
+        public async Task valid_when_empty()
+        {
+            instance.AfterInsert.Clear();
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.AfterInsert );
+        }
+
+        [Fact]
+        public async Task valid_when_has_elements()
+        {
+            instance.AfterInsert.Add( new FakeTransformation() );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.AfterInsert );
+        }
+    }
+
+    public class BeforeUpdate : ValidatorTests
+    {
+        [Fact]
+        public async Task cannot_be_null()
+        {
+            instance = instance with { BeforeUpdate = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.BeforeUpdate );
+        }
+
+        [Fact]
+        public async Task cannot_contain_null_elements()
+        {
+            instance.BeforeUpdate.Add( null! );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.BeforeUpdate );
+        }
+
+        [Fact]
+        public async Task valid_when_empty()
+        {
+            instance.BeforeUpdate.Clear();
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.BeforeUpdate );
+        }
+
+        [Fact]
+        public async Task valid_when_has_elements()
+        {
+            instance.BeforeUpdate.Add( new FakeTransformation() );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.BeforeUpdate );
+        }
+    }
+
+    public class AfterUpdate : ValidatorTests
+    {
+        [Fact]
+        public async Task cannot_be_null()
+        {
+            instance = instance with { AfterUpdate = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.AfterUpdate );
+        }
+
+        [Fact]
+        public async Task cannot_contain_null_elements()
+        {
+            instance.AfterUpdate.Add( null! );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.AfterUpdate );
+        }
+
+        [Fact]
+        public async Task valid_when_empty()
+        {
+            instance.AfterUpdate.Clear();
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.AfterUpdate );
+        }
+
+        [Fact]
+        public async Task valid_when_has_elements()
+        {
+            instance.AfterUpdate.Add( new FakeTransformation() );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.AfterUpdate );
+        }
+    }
 }

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Proprietary
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// All Rights Reserved.
+
+namespace Shipwright.Dataflows.Transformations.DbUpsertTests;
+
+public class ValidatorTests
+{
+    DbUpsert instance = new Fixture().WithDataflowCustomization().Create<DbUpsert>();
+    readonly IValidator<DbUpsert> validator = new DbUpsert.Validator();
+
+    public class ConnectionInfo : ValidatorTests
+    {
+        [Fact]
+        public async Task cannot_be_null()
+        {
+            instance = instance with { ConnectionInfo = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.ConnectionInfo );
+        }
+
+        [Fact]
+        public async Task valid_when_given()
+        {
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.ConnectionInfo );
+        }
+    }
+
+    public class Table : ValidatorTests
+    {
+        [Theory]
+        [InlineData( null )]
+        [WhitespaceCases]
+        public async Task cannot_be_null_or_whitespace( string value )
+        {
+            instance = instance with { Table = value };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Table );
+        }
+
+        [Fact]
+        public async Task valid_when_given()
+        {
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.Table );
+        }
+    }
+}

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -6,8 +6,14 @@ namespace Shipwright.Dataflows.Transformations.DbUpsertTests;
 
 public class ValidatorTests
 {
-    DbUpsert instance = new Fixture().WithDataflowCustomization().Create<DbUpsert>();
+    readonly Fixture _fixture = new Fixture().WithDataflowCustomization();
+    DbUpsert instance;
     readonly IValidator<DbUpsert> validator = new DbUpsert.Validator();
+
+    public ValidatorTests()
+    {
+        instance = _fixture.Create<DbUpsert>();
+    }
 
     public class ConnectionInfo : ValidatorTests
     {
@@ -44,6 +50,80 @@ public class ValidatorTests
         {
             var result = await validator.TestValidateAsync( instance );
             result.ShouldNotHaveValidationErrorFor( _ => _.Table );
+        }
+    }
+
+    public class Fields : ValidatorTests
+    {
+        [Fact]
+        public async Task cannot_be_null()
+        {
+            instance = instance with { Fields = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Fact]
+        public async Task cannot_be_empty()
+        {
+            instance = instance with { Fields = null! };
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Fact]
+        public async Task cannot_have_null_elements()
+        {
+            instance.Fields.Add( null! );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Theory]
+        [InlineData( null )]
+        [WhitespaceCases]
+        public async Task cannot_have_null_or_whitespace_fields( string value )
+        {
+            instance.Fields.Add( _fixture.Create<DbUpsert.FieldMap>() with { Field = value } );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Theory]
+        [InlineData( null )]
+        [WhitespaceCases]
+        public async Task cannot_have_null_or_whitespace_columns( string value )
+        {
+            instance.Fields.Add( _fixture.Create<DbUpsert.FieldMap>() with { Column = value } );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Fact]
+        public async Task requires_a_key_column()
+        {
+            var keys = instance.Fields.Where( _ => _.Type == DbUpsert.ColumnType.Key ).ToArray();
+
+            foreach ( var key in keys )
+                instance.Fields.Remove( key );
+
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Fact]
+        public async Task cannot_have_duplicate_column()
+        {
+            instance.Fields.Add( _fixture.Create<DbUpsert.FieldMap>() with { Column = instance.Fields.First().Column } );
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldHaveValidationErrorFor( _ => _.Fields );
+        }
+
+        [Fact]
+        public async Task valid_when_has_at_least_one_key_and_unique_column_names()
+        {
+            var result = await validator.TestValidateAsync( instance );
+            result.ShouldNotHaveValidationErrorFor( _ => _.Fields );
         }
     }
 }

--- a/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
+++ b/src/Shipwright.Test/Dataflows/Transformations/DbUpsertTests/ValidatorTests.cs
@@ -10,7 +10,7 @@ public class ValidatorTests
     DbUpsert instance;
     readonly IValidator<DbUpsert> validator = new DbUpsert.Validator();
 
-    public ValidatorTests()
+    protected ValidatorTests()
     {
         instance = _fixture.Create<DbUpsert>();
     }


### PR DESCRIPTION
As a developer, I want to handle database inserts and updates with a single transformation so that I can represent those operations clearly and succinctly.

### Minimal updates
Update operations should be minimal. Only records that have changed values should be updated, and only those values that have changed should be updated.

This is achieved by relying on `TryGetChanges`.

### Custom comparers
When a change is detected in an existing record, it should be possible to inject logic to perform a custom comparison of the old and new values to determine whether value replacement is necessary. For example, if my business logic dictates that only null values are replaced in the target table, I should be able to base whether or not the replacement is performed by checking if the column value is currently null in the database.

The optional `Replace` delegate on a field mapping accomplishes this. By default, the `Replace` delegate always returns true, so it is only necessary to define it to handle the conditions when changed values should not be replaced.

### Pre/Post Insert/Update transformations
Some operations may require additional action before or after a database insert or update. For example, it may be necessary to set some default values for certain fields, set timestamps for metadata fields, or add entries to an audit trail.

Consequently, the transformation should support having additional transformations that are executed before/after these events.

This is implemented so that collections of transformations can be defined. For `Insert` and `Trigger` type columns, the `BeforeInsert` and `BeforeUpdate` transformations will allow values to be set for these fields just-in-time (useful for timestamp metadata).

### Key locking
In some use cases, record keys in a dataflow may not be unique (e.g., a data aggregation operation). To avoid database deadlocks, concurrent execution of DbUpsert for two records with the same key values should not be possible.

The `Lock` method and its tendrils handle obtaining record-specific semaphores in a thread-safe manner, awaiting entry, releasing when the transformation ends, and disposing of the semaphore when the last reference is removed (to avoid having a semaphore in memory for every possible key).